### PR TITLE
Fix code scanning alert no. 1: Disabled Spring CSRF protection

### DIFF
--- a/knudev-security/src/main/java/ua/knu/knudev/knudevsecurity/security/config/SecurityConfig.java
+++ b/knudev-security/src/main/java/ua/knu/knudev/knudevsecurity/security/config/SecurityConfig.java
@@ -33,7 +33,6 @@ public class SecurityConfig {
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> {
 //                    String user = AccountRole.USER.name();
 //                    String admin = AccountRole.ADMIN.name();


### PR DESCRIPTION
Fixes [https://github.com/KNUdev/knu-dev/security/code-scanning/1](https://github.com/KNUdev/knu-dev/security/code-scanning/1)

To fix the problem, we need to enable CSRF protection in the `SecurityConfig` class. This involves removing the line that disables CSRF protection and allowing Spring Security to use its default CSRF protection mechanism. This change ensures that the application is protected against CSRF attacks.

Specifically, we need to:
1. Remove the line that disables CSRF protection: `http.csrf(AbstractHttpConfigurer::disable)`.
2. Ensure that CSRF protection is enabled by default, which is the case when no explicit disabling is present.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
